### PR TITLE
fix(generators): apply just_table for all types of pages and articles

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,5 @@
+[flake8]
+
+# [INFO] 120 max line length, 80 is small:
+# https://stackoverflow.com/a/111015/5951529
+max_line_length = 120

--- a/.pylintrc
+++ b/.pylintrc
@@ -1,0 +1,11 @@
+[FORMAT]
+
+max-line-length=120
+
+[CLASSES]
+
+# [INFO] Get protected member “_content” outside the class:
+# https://docs.quantifiedcode.com/python-anti-patterns/correctness/accessing_a_protected_member_from_outside_the_class.html
+# https://github.com/getpelican/pelican/blob/master/pelican/contents.py#L45
+# https://docs.pylint.org/en/1.6.0/features.html#id34
+exclude-protected=_content

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,21 @@
+os: linux
+
+dist: focal
+
+git:
+  depth: 1
+
+cache: false
+
+language: python
+
+python: 3.8
+
+install:
+- pip install --upgrade pip
+- pip install pelican flake8 pydocstyle pylint_runner
+
+script:
+- flake8 .
+- pydocstyle .
+- pylint_runner

--- a/pelican_just_table/__init__.py
+++ b/pelican_just_table/__init__.py
@@ -1,1 +1,2 @@
-from .just_table import *
+"""Initialize plugin."""
+from .just_table import *  # noqa

--- a/pelican_just_table/just_table.py
+++ b/pelican_just_table/just_table.py
@@ -1,23 +1,27 @@
-# -*- coding: utf-8 -*-
-"""
+"""just_table.
+
 Table embedding plugin for Pelican
 =================================
 
 This plugin allows you to create easily table.
 
 """
-from __future__ import unicode_literals
-
+import itertools
 import re
 
-JTABLE_SEPARATOR = 'JTABLE_SEPARATOR'
-JTABLE_TEMPLATE = 'JTABLE_TEMPLATE'
-DEFAULT_SEPARATOR = ','
+from jinja2 import Template
+from pelican import signals
+from pelican.generators import ArticlesGenerator
+from pelican.generators import PagesGenerator
+
+JTABLE_SEPARATOR = "JTABLE_SEPARATOR"
+JTABLE_TEMPLATE = "JTABLE_TEMPLATE"
+DEFAULT_SEPARATOR = ","
 
 AUTO_INCREMENT_REGEX = re.compile(r"ai ?\= ?\" ?(1) ?\"")
+CAPTION_REGEX = re.compile('caption ?= ?"(.+?)"')
+SEPARATOR_REGEX = re.compile('separator ?= ?"(.+?)"')
 TABLE_HEADER_REGEX = re.compile(r"th ?\= ?\" ?(0) ?\"")
-CAPTION_REGEX = re.compile("caption ?\= ?\"(.+?)\"")
-SEPARATOR_REGEX = re.compile("separator ?\= ?\"(.+?)\"")
 MAIN_REGEX = re.compile(r"(\[jtable(.*?)\]([\s\S]*?)\[\/jtable\])")
 
 DEFAULT_TEMPATE = """
@@ -55,9 +59,8 @@ DEFAULT_TEMPATE = """
 """
 
 
-def generate_table(generator):
-    from jinja2 import Template
-
+def just_table(generator, kira_object):
+    """Generate table."""
     if JTABLE_SEPARATOR in generator.settings:
         separator = generator.settings[JTABLE_SEPARATOR]
     else:
@@ -70,42 +73,63 @@ def generate_table(generator):
 
     template = Template(table_template)
 
-    for article in generator.articles + generator.drafts:
-        for match in MAIN_REGEX.findall(article._content):
-            all_match_str, props, table_data = match
-            param = {"ai": 0, "th": 1, "caption": "", "sep": separator}
+    for match in MAIN_REGEX.findall(kira_object._content):
+        all_match_str, props, table_data = match
+        param = {"ai": 0, "th": 1, "caption": "", "sep": separator}
 
-            if AUTO_INCREMENT_REGEX.search(props):
-                param['ai'] = 1
-            if CAPTION_REGEX.search(props):
-                param['caption'] = CAPTION_REGEX.findall(props)[0]
-            if TABLE_HEADER_REGEX.search(props):
-                param["th"] = 0
-            if SEPARATOR_REGEX.search(props):
-                param["sep"] = SEPARATOR_REGEX.findall(props)[0]
+        if AUTO_INCREMENT_REGEX.search(props):
+            param["ai"] = 1
+        if CAPTION_REGEX.search(props):
+            param["caption"] = CAPTION_REGEX.findall(props)[0]
+        if TABLE_HEADER_REGEX.search(props):
+            param["th"] = 0
+        if SEPARATOR_REGEX.search(props):
+            param["sep"] = SEPARATOR_REGEX.findall(props)[0]
 
-            table_data_list = table_data.strip().split('\n')
+        table_data_list = table_data.strip().split("\n")
 
-            if len(table_data_list) >= 1:
-                heads = table_data_list[0].split(param["sep"]) if param['th'] else None
-                if heads:
-                    bodies = [n.split(param["sep"], len(heads) - 1) for n in table_data_list[1:]]
-                else:
-                    bodies = [n.split(param["sep"]) for n in table_data_list]
+        if len(table_data_list) >= 1:
+            heads = table_data_list[0].split(
+                param["sep"]) if param["th"] else None
+            if heads:
+                bodies = [
+                    n.split(param["sep"], len(heads) - 1)
+                    for n in table_data_list[1:]
+                ]
+            else:
+                bodies = [n.split(param["sep"]) for n in table_data_list]
 
-                context = generator.context.copy()
-                context.update({
-                    'heads': heads,
-                    'bodies': bodies,
-                })
-                context.update(param)
+            context = generator.context.copy()
+            context.update({"heads": heads, "bodies": bodies})
+            context.update(param)
 
-                replacement = template.render(context)
-                article._content = article._content.replace(''.join(all_match_str), replacement)
+            replacement = template.render(context)
+            kira_object._content = kira_object._content.replace(
+                "".join(all_match_str), replacement
+            )
+
+
+def run_plugin(generators):
+    """Run generators on both pages and articles."""
+    for generator in generators:
+        # [INFO] Set plugin for articles and pages:
+        # https://github.com/oumpy/hp_management/blob/928b67170a40259599d636cda2b223b8c4350340/myplugins/skiptags.py
+        if isinstance(generator, ArticlesGenerator):
+            # [INFO] Articles types:
+            # https://github.com/getpelican/pelican/blob/d43b786b300358e8a4cbae4afc4052199a7af762/pelican/generators.py#L288-L296
+            for article in itertools.chain(
+                    generator.articles, generator.translations,
+                    generator.drafts, generator.drafts_translations):
+                just_table(generator, article)
+        elif isinstance(generator, PagesGenerator):
+            # [INFO] Pages types:
+            # https://github.com/getpelican/pelican/blob/d43b786b300358e8a4cbae4afc4052199a7af762/pelican/generators.py#L702-L707
+            for page in itertools.chain(
+                    generator.pages, generator.translations, generator.hidden_pages,
+                    generator.hidden_translations, generator.draft_pages, generator.draft_translations):
+                just_table(generator, page)
 
 
 def register():
     """Plugin registration."""
-    from pelican import signals
-
-    signals.article_generator_finalized.connect(generate_table)
+    signals.all_generators_finalized.connect(run_plugin)


### PR DESCRIPTION
### 1. Summary

1. I made just_table generate tables for all types of Pelican articles and pages.
1. Also, I made just_table sources valid. [**flake8**](https://pypi.org/project/flake8/), [**pydocstyle**](http://www.pydocstyle.org/) and [**pylint**](https://www.pylint.org) validation [**passed**](https://travis-ci.com/github/Kristinita/just_table/jobs/392419401#L267-L277). If you want, you can [**add Travis continuous integration to your repository**](https://docs.travis-ci.com/user/tutorial/).

### 2. Changes

I made the changes similar to other Pelican plugins, examples:

1. [**Summary**](https://github.com/getpelican/pelican-plugins/blob/0b9e66ee7b0a3609c1d94e5aeb90144993a1603e/summary/summary.py)
1. [**Exifiscirate**](https://github.com/coyote240/exifiscerate/blob/29519310f10f1e9bd900a11922c256d78fc41173/exifiscerate/exifiscerate.py)
1. [**plugin_pipeline**](https://github.com/dtzWill/wdtz/blob/85c92b0e3bfa1f8004ce23fe0376bec054a0ee46/plugins/plugin_pipeline/plugin_pipeline.py)

### 3. Types of articles and pages

After my changes just_table must work for these types:

1. [**article**](https://docs.getpelican.com/en/latest/content.html#articles-and-pages)
1. article [**translation**](https://docs.getpelican.com/en/latest/content.html#translations)
1. article [**draft**](https://docs.getpelican.com/en/latest/content.html#publishing-drafts)
1. article draft translation
1. [**page**](https://docs.getpelican.com/en/latest/content.html#articles-and-pages)
1. page translation
1. page [**hidden**](https://docs.getpelican.com/en/latest/content.html#pages)
1. page hidden translation
1. page draft
1. page draft translation

### 4. MCVE

You can see it in [**`KiraJustTable` branch**](https://github.com/Kristinita/SashaPelicanDebugging/tree/KiraJustTable) of my demo/debugging repository.

#### 4.1. Data

I use minimal [**pelican-quickstart**](https://docs.getpelican.com/en/latest/quickstart.html) configuration.

1. `pelicanconf.py`:

    ```python
    """MCVE."""

    AUTHOR = 'Sasha Chernykh'
    SITENAME = 'SashaPelicanDebugging'
    SITEURL = 'https://kristinita.netlify.app'

    PATH = 'content'

    TIMEZONE = 'Europe/Moscow'

    DEFAULT_LANG = 'en'

    ARTICLE_PATHS = [
        'Articles'
    ]

    PAGE_PATHS = [
        'Pages'
    ]

    PLUGIN_PATHS = [
        'plugins/just_table'
    ]

    PLUGINS = [
        'pelican_just_table'
    ]
    ```

1. `.travis.yml`:

    ```yaml
    os: linux

    dist: focal

    git:
      depth: 1

    cache: false

    language: python

    python: 3.8

    install:
    - pip install --upgrade pip
    - pip install pelican markdown flake8 pydocstyle pylint pylint_runner

    script:
    - pelican content -s pelicanconf.py --fatal warnings --verbose

    after_success:
    - flake8 .
    - pydocstyle .
    - pylint_runner
    - grep -zorP "<table>(.|\r|\n)*</table>" output --exclude-dir={author,category} --exclude=index.html
    ```

1. Content of each of 10 pages/articles corresponding to one of the types that I described in the `Types of articles and pages` section:

    ```markdown
    [jtable]
    Kira,Goddess
    [/jtable]
    ```

    You can see full metadata of each article and page in the [**`Articles` and `Pages` folders**](https://github.com/Kristinita/SashaPelicanDebugging/tree/KiraJustTable/content) resp.

### 5. Result

+ [**Travis build**](https://travis-ci.org/github/Kristinita/SashaPelicanDebugging/builds/731196982#L345-L435):

    ```html
    $ grep -zorP "<table>(.|\r|\n)*</table>" output --exclude-dir={author,category} --exclude=index.html

    output/KiraArticle-ru.html:<table>

            <thead>

            <tr>

                <th>Kira</th>

                <th>Goddess</th>

            </tr>

            </thead>

            <tbody>

            </tbody>

        </table>output/KiraArticle.html:<table>

            <thead>

            <tr>

                <th>Kira</th>

                <th>Goddess</th>

            </tr>

            </thead>

            <tbody>

            </tbody>

        </table>
    ```

and so on. Table successfully generated for each type of Pelican article/page.

### 6. Testing environment

1. Operating system:

    1. Windows 10.0.18363 Pro N for Workstations 64-bit EN (local)
    1. Ubuntu 20.04.1 LTS (Travis CI)

1. Python 3.8.6
1. Pelican 4.5.0
1. Python Markdown 3.2.2

Thanks.